### PR TITLE
Update user-info.ts - 增加`bot.getUser`的可用性判断

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-memes-api",
   "description": "表情包制作插件调用 API 版",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/src/user-info.ts
+++ b/src/user-info.ts
@@ -54,15 +54,26 @@ export async function apply(ctx: Context, config: Config) {
     }
 
     const fallback = async (): Promise<ImageAndUserInfo> => {
-      const user = await session.bot.getUser(userId, session.guildId)
-      if (!user.avatar) {
-        throw new TypeError(
-          `User ${userId} in platform ${session.platform} has no avatar`,
-        )
-      }
-      return {
-        url: user.avatar,
-        userInfo: { name: user.nick || user.name || '', gender: 'unknown' },
+      let user
+      if (typeof session.bot.getUser === 'function') {
+        user = await session.bot.getUser(userId, session.guildId);
+        if (!user.avatar) {
+          throw new TypeError(`User ${userId} in platform ${session.platform} has no avatar`);
+        }
+        return {
+          url: user.avatar,
+          userInfo: { name: user.nick || user.name || '', gender: 'unknown' },
+        };
+      } else if (session.event.user?.avatar?.includes('http')) {
+        return {
+          url: session.event.user.avatar,
+          userInfo: { name: session.username || session.userId || '', gender: 'unknown' },
+        };
+      } else {
+        return {
+          url: '',
+          userInfo: { name: session.username || session.userId || '', gender: 'unknown' },
+        };
       }
     }
 


### PR DESCRIPTION
adapter-qq 没有对应的接口来实现 `bot.getUser` API

但 `session.event.user?.avatar` 可以获取到用户头像

memes-api 理应增加对`bot.getUser`的可用性判断，加入 `session.event.user?.avatar` 的备选方案

---

效果：

![image](https://github.com/user-attachments/assets/9fa2e172-53dc-48ad-a9dd-c352a2e4cf7c)
